### PR TITLE
Update to latest protobuf

### DIFF
--- a/stream.hpp
+++ b/stream.hpp
@@ -79,7 +79,7 @@ bool for_each(std::istream& in,
           new ::google::protobuf::io::CodedInputStream(gzip_in);
 
     uint64_t count;
-    coded_in->ReadVarint64(&count);
+    coded_in->ReadVarint64((::google::protobuf::uint64*) &count);
     // this loop handles a chunked file with many pieces
     // such as we might write in a multithreaded process
     if (!count) return !count;
@@ -101,7 +101,7 @@ bool for_each(std::istream& in,
                 lambda(object);
             }
         }
-    } while (coded_in->ReadVarint64(&count));
+    } while (coded_in->ReadVarint64((::google::protobuf::uint64*) &count));
 
     delete coded_in;
     delete gzip_in;
@@ -130,7 +130,7 @@ bool for_each_parallel(std::istream& in,
           new ::google::protobuf::io::CodedInputStream(gzip_in);
 
     uint64_t count;
-    bool more_input = coded_in->ReadVarint64(&count);
+    bool more_input = coded_in->ReadVarint64((::google::protobuf::uint64*) &count);
     bool more_objects = false;
     // this loop handles a chunked file with many pieces
     // such as we might write in a multithreaded process
@@ -178,7 +178,7 @@ bool for_each_parallel(std::istream& in,
                         }
                     }
                 }
-                more_input = coded_in->ReadVarint64(&count);
+                more_input = coded_in->ReadVarint64((::google::protobuf::uint64*) &count);
             }
         }
 #pragma omp critical (objects)


### PR DESCRIPTION
I need this so I can actually build Protobuf. There are some changes needed to work around protobuf defining its 64-bit int (on my compiler) differently than int64_t is defined. One of them is a long int, and the other is a long long int, and while both are the same width on my platform, the C++ standard insists that they are different types.
