### PR TITLE
Fix missing return statement

### DIFF
--- a/src/stream.hpp
+++ b/src/stream.hpp
@@ -114,7 +114,7 @@ template <typename T>
 bool for_each(std::istream& in,
               std::function<void(T&)>& lambda) {
     std::function<void(uint64_t)> noop = [](uint64_t) { };
-    for_each(in, lambda, noop);
+    return for_each(in, lambda, noop);
 }
 
 template <typename T>
@@ -197,7 +197,7 @@ template <typename T>
 bool for_each_parallel(std::istream& in,
               std::function<void(T&)>& lambda) {
     std::function<void(uint64_t)> noop = [](uint64_t) { };
-    for_each_parallel(in, lambda, noop);
+    return for_each_parallel(in, lambda, noop);
 }
 
 }


### PR DESCRIPTION
A minor fix to suppress this `g++` error message:

    In function `bool stream::for_each(std::istream&, std::function<void(T&)>&)`:
    error: no return statement in function returning non-void [-Werror=return-type]
    In function `bool stream::for_each_parallel(std::istream&, std::function<void(T&)>&)`:
    error: no return statement in function returning non-void [-Werror=return-type]